### PR TITLE
Load mail credentials from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # DescargasOC
 Este proyecto es un piloto para una automatización de descarga de ordenes de compra desde una aplicación web a un almacenamiento en la nube.
+
+## Credenciales por variables de entorno
+
+`escuchador.py` toma el usuario y la contraseña del servidor POP3 usando las variables de entorno `USUARIO_OC` y `PASSWORD_OC`. Si no se definen, se utilizarán los valores almacenados en el archivo `~/config.json` creado mediante `configurador.py`.

--- a/configurador.py
+++ b/configurador.py
@@ -5,6 +5,9 @@ import json
 
 CONFIG_FILE = os.path.join(os.path.expanduser("~"), "config.json")
 
+USUARIO_ENV = "USUARIO_OC"
+PASSWORD_ENV = "PASSWORD_OC"
+
 def guardar_config(usuario, password, carpeta_destino, carpeta_analizar):
     config = {
         "usuario": usuario,
@@ -25,6 +28,21 @@ def cargar_config():
     except FileNotFoundError:
         print("⚠️ No se encontró configuración previa.")
         return None
+
+def obtener_credenciales():
+    """Devuelve usuario y contraseña desde variables de entorno
+    USUARIO_ENV y PASSWORD_ENV. Si no existen, recurre al archivo
+    de configuración."""
+    config = cargar_config()
+    usuario = os.getenv(USUARIO_ENV)
+    password = os.getenv(PASSWORD_ENV)
+
+    if not usuario and config:
+        usuario = config.get("usuario")
+    if not password and config:
+        password = config.get("password")
+
+    return usuario, password
 
 def configurar():
     def seleccionar_carpeta_destino():

--- a/escuchador.py
+++ b/escuchador.py
@@ -7,12 +7,10 @@ from datetime import datetime, timezone, timedelta
 from email.utils import parsedate_to_datetime
 import selenium_modulo
 
-config = configurador.cargar_config()
+USUARIO, PASSWORD = configurador.obtener_credenciales()
 
 POP_SERVER = "pop.telconet.ec"
 POP_PORT = 995
-USUARIO = config["usuario"]
-PASSWORD = config["password"]
 
 PROCESADOS_FILE = "procesados.txt"
 


### PR DESCRIPTION
## Summary
- support env variables for credentials
- document env variable options

## Testing
- `python -m py_compile configurador.py escuchador.py mover_pdf.py selenium_modulo.py`

------
https://chatgpt.com/codex/tasks/task_e_686757dfce3c8320a620c0ce3542cadd